### PR TITLE
Update Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ sudo newgrp docker
 If the firewall is turned on, you need to open the running port.
 
 ```
-$ sudo firewall-cmd --permanent --add-port=15001-15010/tcp
-$ sudo firewall-cmd --reload
+sudo firewall-cmd --permanent --add-port=15001-15010/tcp
+sudo firewall-cmd --reload
 ```
 
 #### Parameter file
 Download link：http://cess.cloud/FAQ, Article 12.
 Unzip the parameter file and put it in the `/usr/cess-proof-parameters/` directory of the miner
 ```
-$ sudo mkdir -p /usr/cess-proof-parameters
-$ wget https://d2gxbb5i8u5h7r.cloudfront.net/parameterfile.zip
-$ unzip -d /usr/cess-proof-parameters parameterfile.zip
-$ cd /usr/cess-proof-parameters
-$ mv parameterfile/v28-* .
+sudo mkdir -p /usr/cess-proof-parameters
+wget https://d2gxbb5i8u5h7r.cloudfront.net/parameterfile.zip
+sudo unzip -d /usr/cess-proof-parameters parameterfile.zip
+cd /usr/cess-proof-parameters
+mv parameterfile/v28-* .
 ```
 
 ### Polkadot wallet
@@ -84,6 +84,6 @@ idAccountPhraseOrSeed=''
 ## Usage
 * Start mining
 ```
-$ sudo chmod +x start-mining.sh
-$ sudo ./start-mining.sh
+sudo chmod +x start-mining.sh
+sudo ./start-mining.sh
 ```

--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ Unzip the parameter file and put it in the `/usr/cess-proof-parameters/` directo
 ```
 sudo mkdir -p /usr/cess-proof-parameters
 wget https://d2gxbb5i8u5h7r.cloudfront.net/parameterfile.zip
-sudo unzip -d /usr/cess-proof-parameters parameterfile.zip
-cd /usr/cess-proof-parameters
-mv parameterfile/v28-* .
+sudo unzip -j -d /usr/cess-proof-parameters/ parameterfile.zip "parameterfile/*"
 ```
 
 ### Polkadot wallet


### PR DESCRIPTION
- Removed "$" sign from code blocks to easily copy and paste code and added sudo for unzipping in /usr/cess-proof-parameters directory
- Combined 3 commands to 1, that is to unzip parameterfile directory from parameterfile.zip to /usr/cess-proof-parameters/ directory without appending parameterfile directory.